### PR TITLE
Floats failing test

### DIFF
--- a/test.py
+++ b/test.py
@@ -181,5 +181,37 @@ class MHCUDATests(unittest.TestCase):
             print(hashes)
             raise e from None
 
+    def test_float(self):
+        v1 = [
+            0,          1.0497366,  0.8494359,  0.66231006, 0.66231006, 0.8494359,
+            0,          0.66231006, 0.33652836, 0,           0,         0.5359344,
+            0.8494359,  0.66231006, 1.0497366,  0.33652836, 0.66231006, 0.8494359,
+            0.6800841,  0.33652836]
+        gen = libMHCUDA.minhash_cuda_init(len(v1), 128, devices=1, verbosity=2)
+        vars = libMHCUDA.minhash_cuda_retrieve_vars(gen)
+        libMHCUDA.minhash_cuda_fini(gen)
+        gen = libMHCUDA.minhash_cuda_init(
+            len(v1), 128, devices=1, deferred=True, verbosity=2)
+        libMHCUDA.minhash_cuda_assign_vars(gen, *vars)
+        bgen = WeightedMinHashGenerator.__new__(WeightedMinHashGenerator)
+        bgen.dim = len(v1)
+        bgen.rs, bgen.ln_cs, bgen.betas = vars
+        bgen.sample_size = 128
+        bgen.seed = None
+        m = csr_matrix(numpy.array(v1, dtype=numpy.float32))
+        hashes = libMHCUDA.minhash_cuda_calc(gen, m)
+        libMHCUDA.minhash_cuda_fini(gen)
+        self.assertEqual(hashes.shape, (1, 128, 2))
+        true_hashes = numpy.array([bgen.minhash(v1).hashvalues], dtype=numpy.uint32)
+        self.assertEqual(true_hashes.shape, (1, 128, 2))
+        try:
+            self.assertTrue((hashes == true_hashes).all())
+        except AssertionError as e:
+            print("---- TRUE ----")
+            print(true_hashes)
+            print("---- FALSE ----")
+            print(hashes)
+            raise e from None
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Output of the test:

```
mhcuda_init: 20 128 1523273902 0 1 2 0x7ffc1b53188c
GPU #0 has 49152 bytes of shared memory per block
GPU #0 memory: used 757071872 bytes (6.5%), free 10958012416 bytes, total 11715084288 bytes
mhcuda_init: 20 128 1523273902 1 1 2 0x7ffc1b53188c
GPU #0 has 49152 bytes of shared memory per block
GPU #0 memory: used 757071872 bytes (6.5%), free 10958012416 bytes, total 11715084288 bytes
mhcuda_calc: 0x18bcd80 0x210ae40 0x185b3e0 0x1694740 1 0x210b130
Preparing...
split: 1
resizing rows and hashes: 0 -> 1
resizing weights and cols: 0 -> 16
dev #0: binsize 16, bins 32
plans:
[0] 33, 34, 34, 34, 34, 34, 34, 34, 34, 34...
grid_sizes: 1
Executing the CUDA kernel...
dev #0: <<<1, [16, 32], 49152>>>(0, 0)
mhcuda - success
---- TRUE ----
[[[        16          0]
  [        13          0]
  [         5          0]
  [        14          0]
  [        15          0]
  [        16          0]
  [        16          0]
  [         5          0]
  [         4          0]
  [        13          0]
  [        15          0]
  [         5          0]
  [         5          0]
  [        12          0]
  [        15          0]
  [         4          0]
  [        15          0]
  [         5          0]
  [         5          0]
  [        11          0]
  [         7          0]
  [        16          0]
  [        12 4294967295]
  [        11          0]
  [        16          0]
  [        16          0]
  [         5          0]
  [        18          0]
  [         4          0]
  [         2          0]
  [        17          0]
  [         7          0]
  [         7          0]
  [         1          0]
  [        17          0]
  [         5          0]
  [        12          0]
  [         2          0]
  [        11          0]
  [         1          1]
  [         4          0]
  [        13 4294967295]
  [         7          0]
  [        17          0]
  [        12          0]
  [        19          0]
  [         7          0]
  [        17          0]
  [        17          0]
  [         2          0]
  [        12          0]
  [         1          0]
  [        14          0]
  [        16          0]
  [         3          0]
  [         4          0]
  [         7          0]
  [         1          0]
  [        14          0]
  [         8          0]
  [        17          0]
  [        12          0]
  [        13          0]
  [         2          0]
  [         7          0]
  [         3          0]
  [         3          0]
  [         2          0]
  [         2          0]
  [        13          0]
  [         8          0]
  [         4          0]
  [         5          0]
  [        16          0]
  [        17          0]
  [         1          0]
  [         8          0]
  [         2          0]
  [         1          0]
  [         5          0]
  [        12          0]
  [         3          0]
  [        18          0]
  [        14          0]
  [        13          0]
  [         7          0]
  [        12          0]
  [        17          0]
  [         2          0]
  [         7          0]
  [        17          0]
  [         1          0]
  [        18          0]
  [         1          0]
  [         3          0]
  [        11          0]
  [         1          0]
  [         7          0]
  [         5          0]
  [        14          0]
  [        16          0]
  [        19          0]
  [         4          0]
  [        14          0]
  [        14          0]
  [         3          0]
  [        19          0]
  [         4          0]
  [        17          0]
  [         4          0]
  [         1          0]
  [        19          0]
  [         7          0]
  [        13          0]
  [        16          0]
  [        18          0]
  [        13          0]
  [        15          0]
  [         3          0]
  [         2          0]
  [         1          0]
  [        17          0]
  [        15          0]
  [        11          0]
  [         4          0]
  [         1          0]
  [         3          0]
  [         5          0]]]
---- FALSE ----
[[[16  0]
  [13  0]
  [ 5  0]
  [14  0]
  [15  0]
  [16  0]
  [16  0]
  [ 5  0]
  [ 4  0]
  [13  0]
  [15  0]
  [ 5  0]
  [ 5  0]
  [12  0]
  [15  0]
  [ 4  0]
  [15  0]
  [ 5  0]
  [ 5  0]
  [11  0]
  [ 7  0]
  [16  0]
  [12  0]
  [11  0]
  [16  0]
  [16  0]
  [ 5  0]
  [18  0]
  [ 4  0]
  [ 2  0]
  [17  0]
  [ 7  0]
  [ 7  0]
  [ 1  0]
  [17  0]
  [ 5  0]
  [12  0]
  [ 2  0]
  [11  0]
  [ 1  1]
  [ 4  0]
  [13  0]
  [ 7  0]
  [17  0]
  [12  0]
  [19  0]
  [ 7  0]
  [17  0]
  [17  0]
  [ 2  0]
  [12  0]
  [ 1  0]
  [14  0]
  [16  0]
  [ 3  0]
  [ 4  0]
  [ 7  0]
  [ 1  0]
  [14  0]
  [ 8  0]
  [17  0]
  [12  0]
  [13  0]
  [ 2  0]
  [ 7  0]
  [ 3  0]
  [ 3  0]
  [ 2  0]
  [ 2  0]
  [13  0]
  [ 8  0]
  [ 4  0]
  [ 5  0]
  [16  0]
  [17  0]
  [ 1  0]
  [ 8  0]
  [ 2  0]
  [ 1  0]
  [ 5  0]
  [12  0]
  [ 3  0]
  [18  0]
  [14  0]
  [13  0]
  [ 7  0]
  [12  0]
  [17  0]
  [ 2  0]
  [ 7  0]
  [17  0]
  [ 1  0]
  [18  0]
  [ 1  0]
  [ 3  0]
  [11  0]
  [ 1  0]
  [ 7  0]
  [ 5  0]
  [14  0]
  [16  0]
  [19  0]
  [ 4  0]
  [14  0]
  [14  0]
  [ 3  0]
  [19  0]
  [ 4  0]
  [17  0]
  [ 4  0]
  [ 1  0]
  [19  0]
  [ 7  0]
  [13  0]
  [16  0]
  [18  0]
  [13  0]
  [15  0]
  [ 3  0]
  [ 2  0]
  [ 1  0]
  [17  0]
  [15  0]
  [11  0]
  [ 4  0]
  [ 1  0]
  [ 3  0]
  [ 5  0]]]
F
======================================================================
FAIL: test_float (__main__.MHCUDATests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "wmh_test.py", line 42, in test_float
    raise e from None
  File "wmh_test.py", line 36, in test_float
    self.assertTrue((hashes == true_hashes).all())
AssertionError: False is not true
```